### PR TITLE
feat: add nightly link checker GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: volta-cli/action@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4.2.1
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./dist
 
@@ -29,5 +29,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
         id: deployment

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,99 @@
+name: Link Checker
+
+on:
+  # Nightly check of all links
+  schedule:
+    - cron: "0 6 * * *" # 6 AM UTC daily
+  # Check changed files in PRs
+  pull_request:
+    branches: [main]
+  # Manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  # Nightly: check all links in the built site
+  check-all-links:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4.2.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Check all links
+        id: lychee
+        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
+        with:
+          args: >-
+            --root-dir ${{ github.workspace }}/dist
+            --exclude-all-private
+            --exclude 'linkedin\.com'
+            --exclude 'slideshare\.net'
+            --no-progress
+            dist/
+          fail: false
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+        with:
+          title: "Link Checker Report: Broken links found"
+          content-filepath: ./lychee/out.md
+          labels: automated, broken-links
+
+  # PR: check only links in changed files
+  check-pr-links:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: step-security/changed-files@60967b822d3001fa82242f8d6b4ed46bc3600a68 # v47.0.1
+        with:
+          files: |
+            src/**/*.astro
+            src/**/*.md
+            src/**/*.mdx
+            public/**/*.html
+
+      - name: Check links in changed files
+        if: steps.changed-files.outputs.any_changed == 'true'
+        id: lychee
+        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
+        with:
+          args: >-
+            --exclude-all-private
+            --exclude 'linkedin\.com'
+            --exclude 'slideshare\.net'
+            --no-progress
+            ${{ steps.changed-files.outputs.all_changed_files }}
+          fail: true
+
+      - name: Post PR comment on failure
+        if: failure() && steps.lychee.outputs.exit_code != 0
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('./lychee/out.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '## Link Checker Report\n\n' + body + '\n\n---\n*Please fix the broken links or add them to `.lycheeignore` if they are false positives.*'
+            });

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,13 @@
+# Lychee link checker ignore file
+# Add URLs or patterns that should be excluded from link checking
+# https://lychee.cli.rs/usage/config/
+
+# Sites that block automated requests or require authentication
+# (These are also excluded via --exclude in the workflow, but listed here for documentation)
+
+# LinkedIn blocks automated requests
+https://www.linkedin.com/*
+
+# SlideShare often has CAPTCHA or rate limiting
+https://www.slideshare.net/*
+http://www.slideshare.net/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,18 @@ public/
 - **Tailwind**: Mobile-first responsive design, use design tokens from config
 - **Commits**: Conventional commits format (`type(scope): description`)
 
+## GitHub Actions
+
+- **Pin to SHA**: Always pin actions to full SHA commit hashes, not version tags
+- **Version comments**: Include version in a comment for Renovate compatibility
+- **Stable only**: Only use stable releases, never pre-release versions
+- **Security**: Use `step-security/changed-files` instead of `tj-actions/changed-files`
+
+Example:
+```yaml
+- uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+```
+
 ## Content
 
 - 6 blog posts (2012-2015)


### PR DESCRIPTION
- Add links.yml workflow with nightly scheduled check and PR-based checking
- Nightly job builds site and checks all links, creates issue on failure
- PR job checks only changed files using step-security/changed-files
- Add .lycheeignore for sites that block automated requests
- Pin all GitHub Actions to SHA with version comments for Renovate
- Update deploy.yml with SHA-pinned actions
- Update CLAUDE.md with GitHub Actions guidelines